### PR TITLE
System.ArgumentException: 'Expected constant expression' #5

### DIFF
--- a/SqlRepo.SqlServer.Tests/WhereClauseBuilderShould.cs
+++ b/SqlRepo.SqlServer.Tests/WhereClauseBuilderShould.cs
@@ -76,6 +76,15 @@ namespace SqlRepo.SqlServer.Tests
         }
 
         [Test]
+        public void NotThrowForAndedConditionsOnDateTimeProperty()
+        {
+            builder.Where<TestEntity>(e => e.DateTimeProperty > DateTime.UtcNow)
+                .And<TestEntity>(e => e.DateTimeProperty < DateTime.UtcNow)
+                .Invoking(e => e.Sql())
+                .ShouldNotThrow();
+        }
+
+        [Test]
         public void ReturnCorrectSqlForAndedConditionsOnIntProperty()
         {
             const string expected =
@@ -103,7 +112,7 @@ namespace SqlRepo.SqlServer.Tests
                 .Should()
                 .Be(expected);
         }
-
+        
         [Test]
         public void ReturnCorrectSqlForBetween()
         {

--- a/SqlRepo.SqlServer/ClauseBuilder.cs
+++ b/SqlRepo.SqlServer/ClauseBuilder.cs
@@ -91,6 +91,12 @@ namespace SqlRepo.SqlServer
             var memberExpression = expression as MemberExpression;
             if(memberExpression != null)
             {
+                var fieldsOfObj = memberExpression.Expression as ConstantExpression;
+                var propertyInfo = memberExpression.Member as PropertyInfo;
+
+                if (propertyInfo != null)
+                    return propertyInfo.GetValue(fieldsOfObj, null);
+
                 var @value = this.GetExpressionValue(memberExpression.Expression);
                 return this.ResolveValue((dynamic)memberExpression.Member, @value);
             }


### PR DESCRIPTION
Fixed issue where using static members such as DateTime.Now would throw exception.