### PR TITLE
Improved the performance of the DataReaderEntityMapper.

### DIFF
--- a/SqlRepo.SqlServer/DataReaderEntityMapper.cs
+++ b/SqlRepo.SqlServer/DataReaderEntityMapper.cs
@@ -57,7 +57,12 @@ namespace SqlRepo.SqlServer
                     for (var i = 0; i < reader.FieldCount; i++)
                     {
                         var columnName = reader.GetName(i);
+
+                        if (!entityMapper.PropertySetters.ContainsKey(columnName))
+                            continue;
+
                         var propertySetter = entityMapper.PropertySetters[columnName];
+
                         var fieldIndex = i;
 
                         if (entityMapper.ColumnTypeMappings.ContainsKey(columnName))
@@ -269,6 +274,11 @@ namespace SqlRepo.SqlServer
                                 return e;
                             };
                         }
+                    }
+
+                    foreach (var mappingInstruction in mappingInstructions)
+                    {
+                        mappingInstruction?.Invoke(reader, entity);
                     }
                 }
 

--- a/SqlRepo.SqlServer/DataReaderEntityMapper.cs
+++ b/SqlRepo.SqlServer/DataReaderEntityMapper.cs
@@ -43,14 +43,7 @@ namespace SqlRepo.SqlServer
             {
                 var entity = entityMapper.Activator();
 
-                if (!isFirst)
-                {
-                    foreach (var mappingInstruction in mappingInstructions)
-                    {
-                        mappingInstruction?.Invoke(reader, entity);
-                    }
-                }
-                else
+                if (isFirst)
                 {
                     isFirst = false;
 
@@ -275,11 +268,11 @@ namespace SqlRepo.SqlServer
                             };
                         }
                     }
+                }
 
-                    foreach (var mappingInstruction in mappingInstructions)
-                    {
-                        mappingInstruction?.Invoke(reader, entity);
-                    }
+                foreach (var mappingInstruction in mappingInstructions)
+                {
+                    mappingInstruction?.Invoke(reader, entity);
                 }
 
                 list.Add(entity);

--- a/SqlRepo.SqlServer/EntityMapperDefinition.cs
+++ b/SqlRepo.SqlServer/EntityMapperDefinition.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SqlRepo.SqlServer
+{
+    public class EntityMapperDefinition<TEntity> where TEntity : class, new()
+    {
+        public EntityMapperDefinition()
+        {
+            PropertySetters = new Dictionary<string, Action<TEntity, object>>();
+            ColumnTypeMappings = new Dictionary<string, Type>();
+        }
+
+        public Dictionary<string, Action<TEntity, object>> PropertySetters { get; set; }
+        public Dictionary<string, Type> ColumnTypeMappings { get; set; }
+        public EntityActivator<TEntity> Activator { get; set; }
+    }
+}


### PR DESCRIPTION
This PR includes two main changes. When running benchmarks I noticed that we were slow in two areas.

**Selecting a single record**
To improve performance of selecting a single record we store the EntityMapperDefinition in a static list. This definition contains the data types of each of the columns, the compiled lambda property setters, and the object activator. This took TOP 1 select on my benchmark from approx 1.5ms to 0.27ms.

This means first doesn't get any of the performance benefits, but I believe Dapper does a similar thing.

**Selecting a large amount of records**
To improve performance of selecting large amounts of records I have added a new Func<> which is created once for each column of the first record. For the rest of the rows we do not need to figure out what columns we have, or what the data types are. We can just pass our newly created Entity and the Data Reader to our Funcs which are already created. 

I have also removed the IsDBNull check from the non-nullable columns. 

This took selecting 250k records from 70ms to 43ms.